### PR TITLE
Base image should be ose-cli

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -25,7 +25,10 @@ jobs:
     with:
       DOCKER_FILE_PATH: Dockerfile
       CONTAINER_REGISTRY_URL: ghcr.io/stakater
+      RH_CONTAINER_REGISTRY_URL: registry.redhat.io
     secrets:
       CONTAINER_REGISTRY_USERNAME: ${{ github.actor }}
       CONTAINER_REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+      RH_CONTAINER_REGISTRY_USERNAME: ${{ secrets.REGISTRY_REDHAT_USERNAME }}
+      RH_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.REGISTRY_REDHAT_PASSWORD }}
       SLACK_WEBHOOK_URL: ${{ secrets.STAKATER_DELIVERY_SLACK_WEBHOOK }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,9 +11,12 @@ jobs:
     with:
       DOCKER_FILE_PATH: Dockerfile
       RELEASE_BRANCH: main
+      RH_CONTAINER_REGISTRY_URL: registry.redhat.io
     secrets:
       CONTAINER_REGISTRY_URL: ghcr.io/stakater
       CONTAINER_REGISTRY_USERNAME: ${{ github.actor }}
       CONTAINER_REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+      RH_CONTAINER_REGISTRY_USERNAME: ${{ secrets.REGISTRY_REDHAT_USERNAME }}
+      RH_CONTAINER_REGISTRY_PASSWORD: ${{ secrets.REGISTRY_REDHAT_PASSWORD }}
       SLACK_WEBHOOK_URL: ${{ secrets.STAKATER_DELIVERY_SLACK_WEBHOOK }}
       GH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM registry.redhat.io/openshift4/ose-cli:v4.15
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,18 @@ FROM registry.redhat.io/openshift4/ose-cli:v4.15
 
 WORKDIR /app
 
-RUN apk add dumb-init
+RUN dnf -y update && dnf clean all
+RUN dnf install -y jq && dnf clean all
 
-COPY get-versions.sh /
+COPY ./get-versions.sh /
 RUN chmod +x /get-versions.sh
 
-ENTRYPOINT ["dumb-init", "--"]
+ENTRYPOINT ["/get-versions.sh"]
 
-CMD ["/get-versions.sh"]
+LABEL name="Stakater Operator Versions" \
+      maintainer="Stakater <hello@stakater.com>" \
+      vendor="Stakater" \
+      release="1" \
+      summary="Operator Versions"
+
+CMD ["-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,10 @@ RUN chmod +x /get-versions.sh
 
 ENTRYPOINT ["/get-versions.sh"]
 
-LABEL name="Stakater Operator Versions" \
+LABEL name="Operator Versions" \
       maintainer="Stakater <hello@stakater.com>" \
       vendor="Stakater" \
       release="1" \
-      summary="Operator Versions"
+      summary="Get the versions of all operators for an OpenShift cluster"
 
 CMD ["-h"]

--- a/get-versions.sh
+++ b/get-versions.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Script to run on an OpenShift cluster to get all versions of operators
 


### PR DESCRIPTION
* `REGISTRY_REDHAT_USERNAME` and `REGISTRY_REDHAT_PASSWORD` have been added as organizational secrets and shared with this particular repository
* Updating the image to be based on `openshift4/ose-cli` so it can run the oc commands in the shell scripts
* Updating the shell script so it runs as bash